### PR TITLE
#71 Move documentWriter up

### DIFF
--- a/orchestra2md/src/main/java/io/fixprotocol/orchestra2md/MarkdownGenerator.java
+++ b/orchestra2md/src/main/java/io/fixprotocol/orchestra2md/MarkdownGenerator.java
@@ -635,7 +635,6 @@ public class MarkdownGenerator {
     
     final Annotation annotation = actor.getAnnotation();
     generateDocumentationBlocks(annotation, documentWriter);
-    documentWriter.write(context);
 
     final List<Object> elements = actor.getFieldOrFieldRefOrComponent();
     final List<Object> members = elements.stream().filter(e -> !(e instanceof StateMachineType))


### PR DESCRIPTION
@donmendelson I found the issue. The call to `dcoumentWriter.write(context)` was duplicated.