### PR TITLE
#71 Move documentWriter up for the Flow generation

### DIFF
--- a/orchestra2md/src/main/java/io/fixprotocol/orchestra2md/MarkdownGenerator.java
+++ b/orchestra2md/src/main/java/io/fixprotocol/orchestra2md/MarkdownGenerator.java
@@ -1170,9 +1170,9 @@ public class MarkdownGenerator {
     final MutableContext context = contextFactory.createContext(3);
     context.addPair("Flow", flow.getName());
     documentWriter.write(context);
+
     final Annotation annotation = flow.getAnnotation();
     generateDocumentationBlocks(annotation, documentWriter);
-    documentWriter.write(context);
 
     final MutableDetailTable table = contextFactory.createDetailTable();
     final MutableDetailProperties row = table.newRow();


### PR DESCRIPTION
The same applies to the generation of "Flow" elements. Instead of duplicating the `documentWriter.write(context)` it should be moved up. Deleted the second call. Sorry for the omission.