### PR TITLE
Ensure the lengthId attribute is set on fields of type data

### DIFF
--- a/md2orchestra/src/test/java/io/fixprotocol/md2orchestra/RepositoryBuilderTest.java
+++ b/md2orchestra/src/test/java/io/fixprotocol/md2orchestra/RepositoryBuilderTest.java
@@ -1271,4 +1271,23 @@ class RepositoryBuilderTest {
     //System.out.println(errors);
     assertTrue(errors.contains("Unknown type for field"));
   }
+
+  @Test
+  void dataFieldLengthId() throws Exception {
+    String text =
+        "## Fields\n"
+            + "\n"
+            + "| Name | Tag | Type | Values |\n"
+            + "|------------------|----:|--------------|--------------------------|\n"
+            + "| CustomRawData | 10060 | data | |\n";
+
+    InputStream inputStream = new ByteArrayInputStream(text.getBytes());
+    RepositoryBuilder builder = RepositoryBuilder.instance(null , jsonOutputStream);
+    builder.appendInput(inputStream);
+    ByteArrayOutputStream xmlStream = new ByteArrayOutputStream(8096);
+    builder.write(xmlStream);
+    String xml = xmlStream.toString();
+    assertTrue(xml.contains("lengthId=\"10059\""));
+    builder.closeEventLogger();
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<antlr.version>4.8-1</antlr.version>
 		<commons-cli.version>1.4</commons-cli.version>
-		<jackson.version>2.13.4.1</jackson.version>
+		<jackson.version>2.19.2</jackson.version>
 		<java.version>11</java.version>
 		<junit.version>5.9.1</junit.version>
 		<log4j.version>2.19.0</log4j.version>


### PR DESCRIPTION
FIX tags of type data are supposed to be always immediately preceded by a tag containing their length to ensure proper parsing of FIX message. Fields of type data are missing the the lengthId attribute in the XML Orchestra file when generated from a markdown. This change ensure the lengthId is always populated of the field type is "data" and contains the immediately preceding tag id
#79 